### PR TITLE
Grbl version check, timing fix, jogging improvement, bug fixes

### DIFF
--- a/octoprint_bettergrblsupport/__init__.py
+++ b/octoprint_bettergrblsupport/__init__.py
@@ -489,15 +489,7 @@ class BetterGrblSupportPlugin(octoprint.plugin.SettingsPlugin,
             # relative positioning
             self.positioning = 1
 
-        #T2 # HACK:
-        if cmd.upper().lstrip().startswith("X"):
-            match = re.search(r"^X *(-?[\d.]+).*", cmd)
-            if not match is None:
-                command = "G01 " + cmd.upper().strip()
-            else:
-                command = cmd.upper().strip()
-        else:
-            command = cmd.upper().strip()
+        command = cmd.upper().strip()
 
         # keep track of distance traveled
         if command.startswith("G0") or command.startswith("G1") or command.startswith("G2") or command.startswith("G3") or command.startswith("M4"):

--- a/octoprint_bettergrblsupport/__init__.py
+++ b/octoprint_bettergrblsupport/__init__.py
@@ -797,6 +797,7 @@ class BetterGrblSupportPlugin(octoprint.plugin.SettingsPlugin,
         )
 
     def on_api_command(self, command, data):
+
         if command == "sleep":
             self._printer.commands("$SLP")
             return

--- a/octoprint_bettergrblsupport/__init__.py
+++ b/octoprint_bettergrblsupport/__init__.py
@@ -563,9 +563,9 @@ class BetterGrblSupportPlugin(octoprint.plugin.SettingsPlugin,
                                                                                     power=self.grblPowerLevel))
                     self.timeRef = currentTime
 
-            # sending commands too fast seems to produce errors
-            time.sleep(self.cmdDelay)
-            return (command, )
+        # sending commands too fast seems to produce errors
+        time.sleep(self.cmdDelay)
+        return (command, )
 
     # #-- gcode received hook (
     # original author:  https://github.com/mic159

--- a/octoprint_bettergrblsupport/__init__.py
+++ b/octoprint_bettergrblsupport/__init__.py
@@ -937,7 +937,6 @@ class BetterGrblSupportPlugin(octoprint.plugin.SettingsPlugin,
 
         if command == "origin":
             # do origin stuff
-            self._printer.commands("$10=0")
             self._printer.commands("G28.1")
             self._printer.commands("G92 X0 Y0 Z0")
             return

--- a/octoprint_bettergrblsupport/__init__.py
+++ b/octoprint_bettergrblsupport/__init__.py
@@ -897,57 +897,30 @@ class BetterGrblSupportPlugin(octoprint.plugin.SettingsPlugin,
             self._logger.debug("move {} {}".format(direction, distance))
 
             if direction == "home":
-                self._printer.commands("G91")
-                self._printer.commands("G28 X0 Y0")
-                self._printer.commands("G90")
+                self._printer.commands("G90 G0 X0 Y0")
 
             if direction == "forward":
-                self._printer.commands("G91")
-                self._printer.commands("G0 Y{}".format(distance))
-                self._printer.commands("G90")
+                self._printer.commands("G91 G0 Y{}".format(distance))
 
             if direction == "backward":
-                self._printer.commands("G91")
-                self._printer.commands("G0 Y{}".format(distance * -1))
-                self._printer.commands("G90")
+                self._printer.commands("G91 G0 Y{}".format(distance * -1))
 
             if direction == "left":
-                self._printer.commands("G91")
-                self._printer.commands("G0 X{}".format(distance * -1))
-                self._printer.commands("G90")
+                self._printer.commands("G91 G0 X{}".format(distance * -1))
 
             if direction == "right":
-                self._printer.commands("G91")
-                self._printer.commands("G0 X{}".format(distance))
-                self._printer.commands("G90")
+                self._printer.commands("G91 G0 X{}".format(distance))
 
             if direction == "up":
-                self._printer.commands("G91")
-                self._printer.commands("G0 Z{}".format(distance))
-                self._printer.commands("G90")
+                self._printer.commands("G91 G0 Z{}".format(distance))
 
             if direction == "down":
-                self._printer.commands("G91")
-                self._printer.commands("G0 Z{}".format(distance * -1))
-                self._printer.commands("G90")
-
-
+                self._printer.commands("G91 G0 Z{}".format(distance * -1))
             return
 
         if command == "origin":
             # do origin stuff
-            self.ignoreErrors = True
-
-            self._printer.commands("G28.1")
             self._printer.commands("G92 X0 Y0 Z0")
-
-            time.sleep(1)
-
-            self._printer.commands("G28.1")
-            self._printer.commands("G92 X0 Y0 Z0")
-
-            self.ignoreErrors = False
-
             return
 
         if command == "toggleWeak":

--- a/octoprint_bettergrblsupport/static/js/bettergrblsupport.js
+++ b/octoprint_bettergrblsupport/static/js/bettergrblsupport.js
@@ -39,6 +39,7 @@ $(function() {
       self.is_printing = ko.observable(false);
       self.is_operational = ko.observable(false);
 
+      self.grblVersion = ko.observable("N/A");
       self.state = ko.observable("N/A");
       self.xPos = ko.observable("N/A");
       self.yPos = ko.observable("N/A");
@@ -165,7 +166,7 @@ $(function() {
           error: function (data, status) {
             new PNotify({
               title: "Unable to set origin / home!",
-              text: data.responseText + ": " + command,
+              text: data.responseText,
               hide: true,
               buttons: {
                 sticker: false,
@@ -223,6 +224,7 @@ $(function() {
 
       self.onDataUpdaterPluginMessage = function(plugin, data) {
         if (plugin == 'bettergrblsupport' && data.type == 'grbl_state') {
+          self.grblVersion(data.grblVersion);
           self.state(data.state);
           self.xPos(Number.parseFloat(data.x).toFixed(2));
           self.yPos(Number.parseFloat(data.y).toFixed(2));

--- a/octoprint_bettergrblsupport/static/js/bettergrblsupport.js
+++ b/octoprint_bettergrblsupport/static/js/bettergrblsupport.js
@@ -165,7 +165,7 @@ $(function() {
           error: function (data, status) {
             new PNotify({
               title: "Unable to set origin / home!",
-              text: data.responseText,
+              text: data.responseText + ": " + command,
               hide: true,
               buttons: {
                 sticker: false,

--- a/octoprint_bettergrblsupport/templates/bettergrblsupport_tab.jinja2
+++ b/octoprint_bettergrblsupport/templates/bettergrblsupport_tab.jinja2
@@ -120,7 +120,7 @@
                 <td style="padding: 3px 5px 0px 5px;" align="right" valign="middle"><strong data-bind="text: power()"></strong></td>
               </tr>
               <tr>
-                <td style="padding: 3px 10px 5px 5px;" align="right" valign="middle">Speed</td>
+                <td style="padding: 3px 10px 5px 5px;" align="right" valign="middle">Feed</td>
                 <td style="padding: 3px 5px 5px 5px;" align="right" valign="middle"><strong data-bind="text: speed()"></strong></td>
               </tr>
             </table>
@@ -210,7 +210,7 @@
         </table>
       <!-- </td></tr></table> -->
     </td>
-      <td id="laser_buttons" rowspan=5 align="right" valign="middle" width="30%" style="padding: 0px 20px 0px 0px;" >
+      <td id="laser_buttons" rowspan=5 align="right" valign="middle" align="center" width="30%" style="padding: 0px 20px 0px 0px;" >
         <button id="grblLaserButton" style="width: 100px" class="btn" data-bind="enable: is_operational() && !is_printing(), click: function() { toggleWeak() }">Weak Laser</button>
         <br>
         <br>
@@ -223,7 +223,21 @@
         <button style="width: 100px" class="btn" data-bind="enable: is_operational() && !is_printing(), click: function() { sendCommand('unlock') }">Unlock</button>
         <br>
         <br>
-        <button style="width: 100px" class="btn" data-bind="enable: is_operational() && !is_printing(), click: function() { sendCommand('reset') }">Reset</button>
+        <button style="width: 100px" class="btn" data-bind="enable: is_operational(), click: function() { sendCommand('hold') }">Feed Hold</button>
+        <br>
+          <table>
+              <td>
+                <button style="width: 30px" class="btn" data-bind="enable: is_operational(), click: function() { sendCommand('dec_feed') }">-</button>
+              </td>
+              <td>
+                <button style="width: 35px" class="btn" data-bind="enable: is_operational(), click: function() { sendCommand('set_feed') }">o</button>
+              </td>
+              <td>
+                  <button style="width: 30px" class="btn" data-bind="enable: is_operational(), click: function() { sendCommand('inc_feed') }">+</button>
+              </td>
+          </table>
+        <br>
+        <button style="width: 100px" class="btn" data-bind="enable: is_operational(), click: function() { sendCommand('reset') }">Soft-Reset</button>
         <br>
       </td>
       </tr></table>

--- a/octoprint_bettergrblsupport/templates/bettergrblsupport_tab.jinja2
+++ b/octoprint_bettergrblsupport/templates/bettergrblsupport_tab.jinja2
@@ -98,6 +98,10 @@
             <table style="border-spacing: 1px; border: 1px solid;"><tr><td>
             <table border=0>
               <tr>
+                <td style="padding: 5px 10px 0px 5px;" align="right" valign="middle">Grbl.ver:</td>
+                <td style="padding: 5px 5px 0px 5px;" align="right" valign="middle" width="40px"><strong data-bind="text: grblVersion()"></strong></td>
+              </tr>
+              <tr>
                 <td style="padding: 5px 10px 0px 5px;" align="right" valign="middle">State</td>
                 <td style="padding: 5px 5px 0px 5px;" align="right" valign="middle" width="40px"><strong data-bind="text: state()"></strong></td>
               </tr>
@@ -120,7 +124,7 @@
                 <td style="padding: 3px 5px 0px 5px;" align="right" valign="middle"><strong data-bind="text: power()"></strong></td>
               </tr>
               <tr>
-                <td style="padding: 3px 10px 5px 5px;" align="right" valign="middle">Feed</td>
+                <td style="padding: 3px 10px 5px 5px;" align="right" valign="middle">Speed</td>
                 <td style="padding: 3px 5px 5px 5px;" align="right" valign="middle"><strong data-bind="text: speed()"></strong></td>
               </tr>
             </table>
@@ -210,7 +214,7 @@
         </table>
       <!-- </td></tr></table> -->
     </td>
-      <td id="laser_buttons" rowspan=5 align="right" valign="middle" align="center" width="30%" style="padding: 0px 20px 0px 0px;" >
+      <td id="laser_buttons" rowspan=5 align="right" valign="middle" width="30%" style="padding: 0px 20px 0px 0px;" >
         <button id="grblLaserButton" style="width: 100px" class="btn" data-bind="enable: is_operational() && !is_printing(), click: function() { toggleWeak() }">Weak Laser</button>
         <br>
         <br>
@@ -223,21 +227,7 @@
         <button style="width: 100px" class="btn" data-bind="enable: is_operational() && !is_printing(), click: function() { sendCommand('unlock') }">Unlock</button>
         <br>
         <br>
-        <button style="width: 100px" class="btn" data-bind="enable: is_operational(), click: function() { sendCommand('hold') }">Feed Hold</button>
-        <br>
-          <table>
-              <td>
-                <button style="width: 30px" class="btn" data-bind="enable: is_operational(), click: function() { sendCommand('dec_feed') }">-</button>
-              </td>
-              <td>
-                <button style="width: 35px" class="btn" data-bind="enable: is_operational(), click: function() { sendCommand('set_feed') }">o</button>
-              </td>
-              <td>
-                  <button style="width: 30px" class="btn" data-bind="enable: is_operational(), click: function() { sendCommand('inc_feed') }">+</button>
-              </td>
-          </table>
-        <br>
-        <button style="width: 100px" class="btn" data-bind="enable: is_operational(), click: function() { sendCommand('reset') }">Soft-Reset</button>
+        <button style="width: 100px" class="btn" data-bind="enable: is_operational() && !is_printing(), click: function() { sendCommand('reset') }">Reset</button>
         <br>
       </td>
       </tr></table>

--- a/octoprint_bettergrblsupport/templates/bettergrblsupport_tab.jinja2
+++ b/octoprint_bettergrblsupport/templates/bettergrblsupport_tab.jinja2
@@ -227,7 +227,7 @@
         <button style="width: 100px" class="btn" data-bind="enable: is_operational() && !is_printing(), click: function() { sendCommand('unlock') }">Unlock</button>
         <br>
         <br>
-        <button style="width: 100px" class="btn" data-bind="enable: is_operational() && !is_printing(), click: function() { sendCommand('reset') }">Reset</button>
+        <button style="width: 100px; background-color: #f44336" class="btn" data-bind="enable: is_operational(), click: function() { sendCommand('reset') }">Reset<br>E-Stop</button>
         <br>
       </td>
       </tr></table>


### PR DESCRIPTION
- added check for grbl version/display to correctly set status report mask, rather than hard code it for 1.1.  a lot of stuff from asia comes with grbl 0.9 out of the box

-  added small delay of 50ms to command message sending.  using a Raspi 3 B+ or faster computer seems to spam the Arduino too much causing GCode errors. 10ms was not enough.

- allow sending jog commands even while the robot is in Run status so you don't have to wait for it to go Idle again before moving again

- jog control, and origin tool stay in workspace coordinates only rather than mess with G28 machine coordinates commands and modifying the EEPROM

- estop/reset is always available

- removed G01 prefixing which broke modal commands like G2/G3